### PR TITLE
Add support for domain IOC's

### DIFF
--- a/Samples/MISP/constants.py
+++ b/Samples/MISP/constants.py
@@ -12,7 +12,8 @@ ATTR_MAPPING = {
     'size-in-bytes': 'fileSize',
     'url': 'url',
     'user-agent': 'userAgent',
-    'uuid': 'externalId'
+    'uuid': 'externalId',
+    'domain': 'domainName'
 }
 
 MISP_HASH_TYPES = frozenset([


### PR DESCRIPTION
Add domain -> domainName mapping to allow for domain based IOC's to be populated to graph. 

https://github.com/microsoftgraph/security-api-solutions/issues/69