### PR TITLE
Enable specification of config module using '-c' parameter

### DIFF
--- a/Samples/MISP/script.py
+++ b/Samples/MISP/script.py
@@ -1,4 +1,3 @@
-from time import sleep
 from pymisp import PyMISP
 from pymisp import ExpandedPyMISP
 from collections import defaultdict


### PR DESCRIPTION
This functionality allows to pull IoCs from one (or multiple) MISP instance and push them via the MS Graph Security API to MS Sentinel instances on different tenants using the same script. Therefore, the '-c' parameter can be used.

The default behaviour remains the same as before: If the parameter is not defined, the 'config' module is imported.

Example usage:
`python3 script.py -c '<config_module_name>'`

